### PR TITLE
make cygpath more likely to work on recent cygwin installs

### DIFF
--- a/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
+++ b/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
@@ -119,6 +119,11 @@ public class CygpathLauncherDecorator extends LauncherDecorator {
                     key.dispose();
                 }
             } catch (JnaException e) {
+                // ok, let's try usual places...
+                File path = new File("C:\\cygwin");
+                if (path.exists())
+                    return path;
+
                 throw new IOException2("Failed to locate Cygwin installation. Is Cygwin installed?",e);
             }
         }


### PR DESCRIPTION
Newer versions of cygwin use different registry keys to locate
the root directory.  If we can't find the key in the registry,
chances are good that it's installed in the default location, so
try there next.

---

It would be great if we could get some fix in here, even a hack like this -- the original bug is 2 years old or so and will just bite more and more people.

There's also this nearly identical patch that I just saw after writing mine:
https://github.com/rvanoo/cygpath-plugin/commit/443d8ca8f32d7f5cd2a6d8af92763a42cab05a4b
