### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,13 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.418</version>
+    <version>5.17</version>
   </parent>
   
   <artifactId>cygpath</artifactId>
   <version>1.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins Cygpath plugin</name>
-  <description>Performs path conversion with cygpath</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Cygpath+Plugin</url>
   <developers>
     <developer>

--- a/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
+++ b/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
@@ -32,6 +32,8 @@ import hudson.model.Node;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.remoting.Callable;
+import org.jenkinsci.remoting.Role;
+import org.jenkinsci.remoting.RoleChecker;
 import hudson.util.jna.JnaException;
 import hudson.util.jna.RegistryKey;
 
@@ -139,6 +141,10 @@ public class CygpathLauncherDecorator extends LauncherDecorator {
 
         public String call() throws IOException {
             return new File(getCygwinRoot(),"bin\\cygpath").getPath();
+        }
+
+        public void checkRoles(RoleChecker checker) throws SecurityException{
+            checker.check(this, Role.UNKNOWN);
         }
     }
 }

--- a/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
+++ b/src/main/java/hudson/plugins/cygpath/CygpathLauncherDecorator.java
@@ -32,7 +32,6 @@ import hudson.model.Node;
 import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.remoting.Callable;
-import hudson.util.IOException2;
 import hudson.util.jna.JnaException;
 import hudson.util.jna.RegistryKey;
 
@@ -135,7 +134,7 @@ public class CygpathLauncherDecorator extends LauncherDecorator {
                 }
             }
 
-            throw new IOException2("Failed to locate Cygwin installation. Is Cygwin installed?",err);
+            throw new IOException("Failed to locate Cygwin installation. Is Cygwin installed?",err);
         }
 
         public String call() throws IOException {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin performs Cygpath path conversion on Windows slaves so that
   the path of tools in the cluster remains the consistent across platforms. 


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
